### PR TITLE
ci: initial commit for gmbuilder

### DIFF
--- a/.github/workflows/test-tutorial.yml
+++ b/.github/workflows/test-tutorial.yml
@@ -16,4 +16,4 @@ jobs:
               compose-file: "./gmbuilder-docker-compose.yml"
               up-flags: "--build"
           - name: Test the GM tutorial
-            run: ./script.sh
+            run: ./gm-tester.sh

--- a/.github/workflows/test-tutorial.yml
+++ b/.github/workflows/test-tutorial.yml
@@ -1,10 +1,19 @@
 name: Test GM Tutorial
-on: workflow_dispatch
+on: push
 
 permissions:
   contents: read
 
 jobs:
     test:
-        runs-on: golang:1.20.3
+        runs-on: ubuntu-latest
         steps:
+          - name: Checkout repository
+            uses: actions/checkout@v3
+          - name: Run GM tutorial in docker-compose
+            uses: isbang/compose-action@v1.5.0
+            with:
+              compose-file: "./gmbuilder-docker-compose.yml"
+              up-flags: "--build"
+          - name: Test the GM tutorial
+            run: ./script.sh

--- a/.github/workflows/test-tutorial.yml
+++ b/.github/workflows/test-tutorial.yml
@@ -1,0 +1,10 @@
+name: Test GM Tutorial
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+    test:
+        runs-on: golang:1.20.3
+        steps:

--- a/.github/workflows/test-tutorial.yml
+++ b/.github/workflows/test-tutorial.yml
@@ -8,8 +8,6 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-          - name: Checkout repository
-            uses: actions/checkout@v3
           - name: Run GM tutorial in docker-compose
             uses: isbang/compose-action@v1.5.0
             with:

--- a/.github/workflows/test-tutorial.yml
+++ b/.github/workflows/test-tutorial.yml
@@ -8,6 +8,8 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
+          - name: Checkout repository
+            uses: actions/checkout@v3
           - name: Run GM tutorial in docker-compose
             uses: isbang/compose-action@v1.5.0
             with:

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -12,16 +12,25 @@ RETRY_COUNT=0
 # Loop until the result is not equal to the expected string or maximum retries are reached
 while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
   # Execute the curl command and capture the result
-  RESULT=$(curl -s "$URL" | jq -r '.result')
+  RESULT=$(curl -s "$URL")
 
   # Compare the result with the expected string or null string
-  if [["$RESULT" != "null"]]; then
-    echo "Success! The result is now not null. Specifically, it's:"
+  if jq -e '.result' <<< "$RESULT" > /dev/null; then
+    echo "Success! The result is now different from the error"
+    echo "got result:"
     echo $RESULT
+    echo "but we expected this:"
+    echo $EXPECTED_RESULT
+    if [ -z "$RESULT" ]; then
+      echo "Result is null. not good"
+    else
+      echo "result is NOT NULL"
+    fi
     exit 0
     break
   fi
-  echo "i think the result is null."
+  echo "EXPECTED " $EXPECTED_RESULT
+  echo "GOT " $RESULT
 
   # Increment the retry count
   ((RETRY_COUNT++))

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -16,21 +16,11 @@ while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
 
   # Compare the result with the expected string or null string
   if jq -e '.result' <<< "$RESULT" > /dev/null; then
-    echo "Success! The result is now different from the error"
-    echo "got result:"
+    echo "Rollup has produced block #3:"
     echo $RESULT
-    echo "but we expected this:"
-    echo $EXPECTED_RESULT
-    if [ -z "$RESULT" ]; then
-      echo "Result is null. not good"
-    else
-      echo "result is NOT NULL"
-    fi
     exit 0
     break
   fi
-  echo "EXPECTED " $EXPECTED_RESULT
-  echo "GOT " $RESULT
 
   # Increment the retry count
   ((RETRY_COUNT++))

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -1,6 +1,4 @@
 URL=localhost:26657/block\?height=3
-EXPECTED_RESULT='{"jsonrpc":"2.0","error":{"code":-32603,"message":"","data":"failed to load hash from index: failed to load block hash for height: datastore: key not found"},"id":-1}'
-EXPECTED_RESULT="${EXPECTED_RESULT#"${EXPECTED_RESULT%%[![:space:]]*}"}"
 
 # Define the maximum number of retries
 MAX_RETRIES=50
@@ -14,26 +12,16 @@ RETRY_COUNT=0
 # Loop until the result is not equal to the expected string or maximum retries are reached
 while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
   # Execute the curl command and capture the result
-  RESULT=$(curl -s "$URL")
-  RESULT="${RESULT#"${RESULT%%[![:space:]]*}"}"
+  RESULT=$(curl -s "$URL" | jq '.result')
 
   # Compare the result with the expected string or null string
-  if [[ "$RESULT" != "$EXPECTED_RESULT" && -n "$RESULT" ]]; then
-    echo "Success! The result is now different from the error"
-    echo "got result:"
+  if ["$RESULT" != "null"]; then
+    echo "Success! The result is now not null. Specifically, it's:"
     echo $RESULT
-    echo "but we expected this:"
-    echo $EXPECTED_RESULT
-    if [ -z "$RESULT" ]; then
-      echo "Result is null. not good"
-    else
-      echo "result is NOT NULL"
-    fi
     exit 0
     break
   fi
-  echo "EXPECTED " $EXPECTED_RESULT
-  echo "GOT " $RESULT
+  echo "i think the result is null."
 
   # Increment the retry count
   ((RETRY_COUNT++))

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -15,7 +15,7 @@ while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
   RESULT=$(curl -s "$URL" | jq '.result')
 
   # Compare the result with the expected string or null string
-  if ["$RESULT" != "null"]; then
+  if [["$RESULT" != "null"]]; then
     echo "Success! The result is now not null. Specifically, it's:"
     echo $RESULT
     exit 0

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -12,7 +12,7 @@ RETRY_COUNT=0
 # Loop until the result is not equal to the expected string or maximum retries are reached
 while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
   # Execute the curl command and capture the result
-  RESULT=$(curl -s "$URL" | jq '.result')
+  RESULT=$(curl -s "$URL" | jq -r '.result')
 
   # Compare the result with the expected string or null string
   if [["$RESULT" != "null"]]; then

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -1,5 +1,6 @@
 URL=localhost:26657/block\?height=3
 EXPECTED_RESULT='{"jsonrpc":"2.0","error":{"code":-32603,"message":"","data":"failed to load hash from index: failed to load block hash for height: datastore: key not found"},"id":-1}'
+EXPECTED_RESULT="${EXPECTED_RESULT#"${EXPECTED_RESULT%%[![:space:]]*}"}"
 
 # Define the maximum number of retries
 MAX_RETRIES=50
@@ -14,6 +15,7 @@ RETRY_COUNT=0
 while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
   # Execute the curl command and capture the result
   RESULT=$(curl -s "$URL")
+  RESULT="${RESULT#"${RESULT%%[![:space:]]*}"}"
 
   # Compare the result with the expected string or null string
   if [[ "$RESULT" != "$EXPECTED_RESULT" && -n "$RESULT" ]]; then

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 URL=localhost:26657/block\?height=3
 
 # Define the maximum number of retries

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -18,7 +18,13 @@ while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
   # Compare the result with the expected string or null string
   if [[ "$RESULT" != "$EXPECTED_RESULT" && -n "$RESULT" ]]; then
     echo "Success! The result is now different from the error"
+    echo "got result:"
     echo $RESULT
+    if [ -z "$RESULT" ]; then
+      echo "Result is null. not good"
+    else
+      echo "result is NOT NULL"
+    fi
     exit 0
     break
   fi

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 URL=localhost:26657/block\?height=3
 
 # Define the maximum number of retries

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -20,6 +20,8 @@ while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
     echo "Success! The result is now different from the error"
     echo "got result:"
     echo $RESULT
+    echo "but we expected this:"
+    echo $EXPECTED_RESULT
     if [ -z "$RESULT" ]; then
       echo "Result is null. not good"
     else

--- a/gm-tester.sh
+++ b/gm-tester.sh
@@ -1,0 +1,42 @@
+URL=localhost:26657/block\?height=3
+EXPECTED_RESULT='{"jsonrpc":"2.0","error":{"code":-32603,"message":"","data":"failed to load hash from index: failed to load block hash for height: datastore: key not found"},"id":-1}'
+
+# Define the maximum number of retries
+MAX_RETRIES=50
+
+# Define the delay between retries in seconds
+RETRY_DELAY=5
+
+# Counter for the number of retries
+RETRY_COUNT=0
+
+# Loop until the result is not equal to the expected string or maximum retries are reached
+while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+  # Execute the curl command and capture the result
+  RESULT=$(curl -s "$URL")
+
+  # Compare the result with the expected string or null string
+  if [[ "$RESULT" != "$EXPECTED_RESULT" && -n "$RESULT" ]]; then
+    echo "Success! The result is now different from the error"
+    echo $RESULT
+    exit 0
+    break
+  fi
+  echo "EXPECTED " $EXPECTED_RESULT
+  echo "GOT " $RESULT
+
+  # Increment the retry count
+  ((RETRY_COUNT++))
+
+  # Display a retry message
+  echo "Retrying... (Attempt $RETRY_COUNT)"
+
+  # Sleep for the specified delay before the next retry
+  sleep $RETRY_DELAY
+done
+
+# Check if maximum retries are reached without success
+if [[ $RETRY_COUNT -eq $MAX_RETRIES ]]; then
+  echo "Maximum retries reached. Unable to obtain a different result."
+fi
+exit 1

--- a/gmbuilder-docker-compose.yml
+++ b/gmbuilder-docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+services:
+  celestia:
+    image: ghcr.io/rollkit/local-celestia-devnet:latest
+    # Rollup can't start until after DA starts.
+    # This ensures it waits 5 seconds so the rollup can query it.
+    ports:
+      - "26657:26657"
+      - "26659:26659"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:26657/block?height=1"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
+  gm:
+    build:
+      context: .
+      dockerfile: gmbuilder.Dockerfile
+    environment:
+      COSMOS_CHECKOUT: "c615611b4"
+    depends_on:
+      celestia:
+        condition: service_healthy

--- a/gmbuilder-docker-compose.yml
+++ b/gmbuilder-docker-compose.yml
@@ -16,8 +16,8 @@ services:
     build:
       context: .
       dockerfile: gmbuilder.Dockerfile
-    environment:
-      COSMOS_CHECKOUT: "c615611b4"
     depends_on:
       celestia:
         condition: service_healthy
+    ports:
+      - "36657:26657"

--- a/gmbuilder.Dockerfile
+++ b/gmbuilder.Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.20.3
+
+WORKDIR /
+
+ADD ./ /cosmos-sdk/
+
+COPY script.sh /script.sh
+RUN chmod +x /script.sh
+ENTRYPOINT /bin/bash /script.sh

--- a/gmbuilder.Dockerfile
+++ b/gmbuilder.Dockerfile
@@ -4,6 +4,5 @@ WORKDIR /
 
 ADD ./ /cosmos-sdk/
 
-COPY script.sh /script.sh
-RUN chmod +x /script.sh
+COPY --chmod=+x script.sh /script.sh
 ENTRYPOINT /bin/bash /script.sh

--- a/script.sh
+++ b/script.sh
@@ -56,24 +56,24 @@ cat .bashrc
 
 
 # reset any existing genesis/chain data
-/home/runner/gmd tendermint unsafe-reset-all
+/home/runner/go/bin/gmd tendermint unsafe-reset-all
 
 # initialize the validator with the chain ID you set
-/home/runner/gmd init $VALIDATOR_NAME --chain-id $CHAIN_ID
+/home/runner/go/bin/gmd init $VALIDATOR_NAME --chain-id $CHAIN_ID
 
 # add keys for key 1 and key 2 to keyring-backend test
-echo y | /home/runner/gmd keys add $KEY_NAME --keyring-backend test
-echo y | /home/runner/gmd keys add $KEY_2_NAME --keyring-backend test
+echo y | /home/runner/go/bin/gmd keys add $KEY_NAME --keyring-backend test
+echo y | /home/runner/go/bin/gmd keys add $KEY_2_NAME --keyring-backend test
 
 # add these as genesis accounts
-/home/runner/gmd add-genesis-account $KEY_NAME $TOKEN_AMOUNT --keyring-backend test
-/home/runner/gmd add-genesis-account $KEY_2_NAME $TOKEN_AMOUNT --keyring-backend test
+/home/runner/go/bin/gmd add-genesis-account $KEY_NAME $TOKEN_AMOUNT --keyring-backend test
+/home/runner/go/bin/gmd add-genesis-account $KEY_2_NAME $TOKEN_AMOUNT --keyring-backend test
 
 # set the staking amounts in the genesis transaction
-/home/runner/gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
+/home/runner/go/bin/gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
 
 # collect genesis transactions
-/home/runner/gmd collect-gentxs
+/home/runner/go/bin/gmd collect-gentxs
 
 # query the DA Layer start height, in this case we are querying
 # our local devnet at port 26657, the RPC. The RPC endpoint is
@@ -85,4 +85,4 @@ echo $DA_BLOCK_HEIGHT
 
 # start the chain
 echo "Starting rollup in foreground!"
-/home/runner/gmd start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config='{"base_url":"http://celestia:26659","timeout":60000000000,"fee":6000,"gas_limit":6000000}' --rollkit.namespace_id $NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT
+/home/runner/go/bin/gmd start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config='{"base_url":"http://celestia:26659","timeout":60000000000,"fee":6000,"gas_limit":6000000}' --rollkit.namespace_id $NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT

--- a/script.sh
+++ b/script.sh
@@ -52,26 +52,28 @@ ls -a
 cd /home/runner/work
 echo "pwd: $PWD"
 ls -a
+cat .bashrc
+
 
 # reset any existing genesis/chain data
-gmd tendermint unsafe-reset-all
+/home/runner/gmd tendermint unsafe-reset-all
 
 # initialize the validator with the chain ID you set
-gmd init $VALIDATOR_NAME --chain-id $CHAIN_ID
+/home/runner/gmd init $VALIDATOR_NAME --chain-id $CHAIN_ID
 
 # add keys for key 1 and key 2 to keyring-backend test
-echo y | gmd keys add $KEY_NAME --keyring-backend test
-echo y | gmd keys add $KEY_2_NAME --keyring-backend test
+echo y | /home/runner/gmd keys add $KEY_NAME --keyring-backend test
+echo y | /home/runner/gmd keys add $KEY_2_NAME --keyring-backend test
 
 # add these as genesis accounts
-gmd add-genesis-account $KEY_NAME $TOKEN_AMOUNT --keyring-backend test
-gmd add-genesis-account $KEY_2_NAME $TOKEN_AMOUNT --keyring-backend test
+/home/runner/gmd add-genesis-account $KEY_NAME $TOKEN_AMOUNT --keyring-backend test
+/home/runner/gmd add-genesis-account $KEY_2_NAME $TOKEN_AMOUNT --keyring-backend test
 
 # set the staking amounts in the genesis transaction
-gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
+/home/runner/gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
 
 # collect genesis transactions
-gmd collect-gentxs
+/home/runner/gmd collect-gentxs
 
 # query the DA Layer start height, in this case we are querying
 # our local devnet at port 26657, the RPC. The RPC endpoint is
@@ -83,4 +85,4 @@ echo $DA_BLOCK_HEIGHT
 
 # start the chain
 echo "Starting rollup in foreground!"
-gmd start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config='{"base_url":"http://celestia:26659","timeout":60000000000,"fee":6000,"gas_limit":6000000}' --rollkit.namespace_id $NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT
+/home/runner/gmd start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config='{"base_url":"http://celestia:26659","timeout":60000000000,"fee":6000,"gas_limit":6000000}' --rollkit.namespace_id $NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT

--- a/script.sh
+++ b/script.sh
@@ -33,7 +33,16 @@ echo "running ls -a"
 ls -a
 echo "going back 1"
 cd ..
+echo "PWD is:"
+echo $PWD
 ls -a
+echo "going into cosmos-sdk"
+cd cosmos-sdk
+ls -a
+echo "going into gm"
+cd gm
+ls -a
+
 # reset any existing genesis/chain data
 gmd tendermint unsafe-reset-all
 

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd ..
-apt update
-apt install jq -y
+sudo apt-get update
+sudo apt-get install jq -y
 curl https://get.ignite.com/cli@v0.26.1! | bash
 ignite scaffold chain gm --address-prefix gm
 cd gm

--- a/script.sh
+++ b/script.sh
@@ -1,9 +1,10 @@
+#!/bin/bash
 apt update
 apt install jq -y
 curl https://get.ignite.com/cli@v0.26.1! | bash
 ignite scaffold chain gm --address-prefix gm
 cd gm
-go mod edit -replace github.com/cosmos/cosmos-sdk=../cosmos-sdk
+go mod edit -replace github.com/cosmos/cosmos-sdk=./cosmos-sdk
 go mod edit -replace github.com/tendermint/tendermint=github.com/rollkit/cometbft@v0.0.0-20230524013049-75272ebaee38
 go mod tidy
 go mod download

--- a/script.sh
+++ b/script.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-/bin/bash ~/.bashrc
+echo $PWD
+echo "running ls:"
+ls
 apt update
 apt install jq -y
 curl https://get.ignite.com/cli@v0.26.1! | bash
 ignite scaffold chain gm --address-prefix gm
 cd gm
-go mod edit -replace github.com/cosmos/cosmos-sdk=../
+go mod edit -replace github.com/cosmos/cosmos-sdk=/cosmos-sdk
 go mod edit -replace github.com/tendermint/tendermint=github.com/rollkit/cometbft@v0.0.0-20230524013049-75272ebaee38
 go mod tidy
 go mod download

--- a/script.sh
+++ b/script.sh
@@ -8,7 +8,7 @@ apt install jq -y
 curl https://get.ignite.com/cli@v0.26.1! | bash
 ignite scaffold chain gm --address-prefix gm
 cd gm
-go mod edit -replace github.com/cosmos/cosmos-sdk=/cosmos-sdk
+go mod edit -replace github.com/cosmos/cosmos-sdk=../cosmos-sdk
 go mod edit -replace github.com/tendermint/tendermint=github.com/rollkit/cometbft@v0.0.0-20230524013049-75272ebaee38
 go mod tidy
 go mod download
@@ -27,6 +27,13 @@ echo $NAMESPACE_ID
 
 # build the gm chain with Rollkit
 ignite chain build
+echo "PWD is:"
+echo $PWD
+echo "running ls -a"
+ls -a
+echo "going back 1"
+cd ..
+ls -a
 # reset any existing genesis/chain data
 gmd tendermint unsafe-reset-all
 

--- a/script.sh
+++ b/script.sh
@@ -25,24 +25,26 @@ echo $NAMESPACE_ID
 # build the gm chain with Rollkit
 ignite chain build
 # reset any existing genesis/chain data
-/home/runner/go/bin/gmd tendermint unsafe-reset-all
+#/home/runner/go/bin/gmd tendermint unsafe-reset-all
+gmd tendermint unsafe-reset-all
 
 # initialize the validator with the chain ID you set
-/home/runner/go/bin/gmd init $VALIDATOR_NAME --chain-id $CHAIN_ID
+#/home/runner/go/bin/gmd init $VALIDATOR_NAME --chain-id $CHAIN_ID
+gmd init $VALIDATOR_NAME --chain-id $CHAIN_ID
 
 # add keys for key 1 and key 2 to keyring-backend test
 echo y | /home/runner/go/bin/gmd keys add $KEY_NAME --keyring-backend test
 echo y | /home/runner/go/bin/gmd keys add $KEY_2_NAME --keyring-backend test
 
 # add these as genesis accounts
-/home/runner/go/bin/gmd add-genesis-account $KEY_NAME $TOKEN_AMOUNT --keyring-backend test
-/home/runner/go/bin/gmd add-genesis-account $KEY_2_NAME $TOKEN_AMOUNT --keyring-backend test
+gmd add-genesis-account $KEY_NAME $TOKEN_AMOUNT --keyring-backend test
+gmd add-genesis-account $KEY_2_NAME $TOKEN_AMOUNT --keyring-backend test
 
 # set the staking amounts in the genesis transaction
-/home/runner/go/bin/gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
+gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
 
 # collect genesis transactions
-/home/runner/go/bin/gmd collect-gentxs
+gmd collect-gentxs
 
 # query the DA Layer start height, in this case we are querying
 # our local devnet at port 26657, the RPC. The RPC endpoint is

--- a/script.sh
+++ b/script.sh
@@ -4,7 +4,7 @@ apt install jq -y
 curl https://get.ignite.com/cli@v0.26.1! | bash
 ignite scaffold chain gm --address-prefix gm
 cd gm
-go mod edit -replace github.com/cosmos/cosmos-sdk=./cosmos-sdk
+go mod edit -replace github.com/cosmos/cosmos-sdk=../
 go mod edit -replace github.com/tendermint/tendermint=github.com/rollkit/cometbft@v0.0.0-20230524013049-75272ebaee38
 go mod tidy
 go mod download

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,55 @@
+apt update
+apt install jq -y
+curl https://get.ignite.com/cli@v0.26.1! | bash
+ignite scaffold chain gm --address-prefix gm
+cd gm
+go mod edit -replace github.com/cosmos/cosmos-sdk=../cosmos-sdk
+go mod edit -replace github.com/tendermint/tendermint=github.com/rollkit/cometbft@v0.0.0-20230524013049-75272ebaee38
+go mod tidy
+go mod download
+
+VALIDATOR_NAME=validator1
+CHAIN_ID=gm
+KEY_NAME=gm-key
+KEY_2_NAME=gm-key-2
+CHAINFLAG="--chain-id ${CHAIN_ID}"
+TOKEN_AMOUNT="10000000000000000000000000stake"
+STAKING_AMOUNT="1000000000stake"
+
+# create a random Namespace ID for your rollup to post blocks to
+NAMESPACE_ID=$(openssl rand -hex 8)
+echo $NAMESPACE_ID
+
+# build the gm chain with Rollkit
+ignite chain build
+# reset any existing genesis/chain data
+gmd tendermint unsafe-reset-all
+
+# initialize the validator with the chain ID you set
+gmd init $VALIDATOR_NAME --chain-id $CHAIN_ID
+
+# add keys for key 1 and key 2 to keyring-backend test
+echo y | gmd keys add $KEY_NAME --keyring-backend test
+echo y | gmd keys add $KEY_2_NAME --keyring-backend test
+
+# add these as genesis accounts
+gmd add-genesis-account $KEY_NAME $TOKEN_AMOUNT --keyring-backend test
+gmd add-genesis-account $KEY_2_NAME $TOKEN_AMOUNT --keyring-backend test
+
+# set the staking amounts in the genesis transaction
+gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
+
+# collect genesis transactions
+gmd collect-gentxs
+
+# query the DA Layer start height, in this case we are querying
+# our local devnet at port 26657, the RPC. The RPC endpoint is
+# to allow users to interact with Celestia's nodes by querying
+# the node's state and broadcasting transactions on the Celestia
+# network. The default port is 26657.
+DA_BLOCK_HEIGHT=$(curl http://celestia:26657/block | jq -r '.result.block.header.height')
+echo $DA_BLOCK_HEIGHT
+
+# start the chain
+echo "Starting rollup in foreground!"
+gmd start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config='{"base_url":"http://celestia:26659","timeout":60000000000,"fee":6000,"gas_limit":6000000}' --rollkit.namespace_id $NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT

--- a/script.sh
+++ b/script.sh
@@ -46,6 +46,12 @@ echo "trying to go to home..."
 cd /home/
 echo "did it work? $PWD"
 ls -a
+cd /home/runner/
+echo "pwd: $PWD"
+ls -a
+cd /home/runner/work
+echo "pwd: $PWD"
+ls -a
 
 # reset any existing genesis/chain data
 gmd tendermint unsafe-reset-all

--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd ..
 echo $PWD
 echo "running ls:"
 ls

--- a/script.sh
+++ b/script.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 cd ..
-echo $PWD
-echo "running ls:"
-ls
 apt update
 apt install jq -y
 curl https://get.ignite.com/cli@v0.26.1! | bash
@@ -27,34 +24,6 @@ echo $NAMESPACE_ID
 
 # build the gm chain with Rollkit
 ignite chain build
-echo "PWD is:"
-echo $PWD
-echo "running ls -a"
-ls -a
-echo "going back 1"
-cd ..
-echo "PWD is:"
-echo $PWD
-ls -a
-echo "going into cosmos-sdk"
-cd cosmos-sdk
-ls -a
-echo "going into gm"
-cd gm
-ls -a
-echo "trying to go to home..."
-cd /home/
-echo "did it work? $PWD"
-ls -a
-cd /home/runner/
-echo "pwd: $PWD"
-ls -a
-cd /home/runner/work
-echo "pwd: $PWD"
-ls -a
-cat .bashrc
-
-
 # reset any existing genesis/chain data
 /home/runner/go/bin/gmd tendermint unsafe-reset-all
 

--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+/bin/bash ~/.bashrc
 apt update
 apt install jq -y
 curl https://get.ignite.com/cli@v0.26.1! | bash

--- a/script.sh
+++ b/script.sh
@@ -42,6 +42,10 @@ ls -a
 echo "going into gm"
 cd gm
 ls -a
+echo "trying to go to home..."
+cd /home/
+echo "did it work? $PWD"
+ls -a
 
 # reset any existing genesis/chain data
 gmd tendermint unsafe-reset-all


### PR DESCRIPTION
forked a specific release that works with the tutorial, because cosmos-sdk has no main branch.
- gmbuilder-docker-compose.yml starts the gmbuilder.Dockerfile which builds and runs the tutorial alongside a Celestia local devnet 
- `gm-tester.sh` polls the rollup for block #3 (could add other behavior, perhaps testing transactions)
- `.github/workflows/test-tutorial.yml` automates the test